### PR TITLE
Update parse_line.c

### DIFF
--- a/minishell/Makefile
+++ b/minishell/Makefile
@@ -24,29 +24,30 @@ INCS_DIR	= ./includes/
 SRCS_DIR	= ./srcs/
 OBJS_DIR	= ./objs/
 
-SRC			= error.c \
+SRC			= add_export.c \
+			  builtin.c \
+			  error.c \
+			  exe_cd.c \
+			  exe_echo.c \
+			  exe_env.c \
+			  exe_exit.c \
+			  exe_export.c \
+			  exe_process_utils.c \
+			  exe_process.c \
+			  exe_pwd.c \
+			  exe_unset.c \
+			  list.c \
 			  main.c \
 			  parse_command.c \
 			  parse_line.c \
+			  redirect_utils.c \
+			  redirect.c \
 			  replace.c \
+			  search_export.c \
+			  signal.c \
 			  utils_cmd.c \
 			  utils_redir.c \
-			  	signal.c \
-				redirect.c \
-				exe_process.c \
-				exe_env.c \
-				exe_cd.c \
-				exe_echo.c \
-				exe_pwd.c \
-				exe_export.c \
-				exe_unset.c \
-				exe_exit.c \
-				utils.c \
-				builtin.c \
-				list.c \
-				add_export.c \
-				redirect_utils.c \
-				exe_process_utils.c 
+			  utils.c
 
 
 SRCS		= $(addprefix $(SRCS_DIR), $(SRC))
@@ -54,12 +55,12 @@ OBJS		= $(addprefix $(OBJS_DIR), $(SRC:.c=.o))
 
 $(TARGET) : $(OBJS)
 	make -C $(LIBFT_DIR)
-	$(CC) $(CFLAGS) -o $(TARGET) $(OBJS) -I $(INCS_DIR) -L$(LIBFT_DIR) -lft -lreadline -L/usr/local/opt/readline/lib -I/usr/local/opt/readline/include
+	$(CC) $(CFLAGS) -o $(TARGET) $(OBJS) -I $(INCS_DIR) -L$(LIBFT_DIR) -lft -lreadline -L ~/.brew/opt/readline/lib -I ~/.brew/opt/readline/include
 	#cluster : -lreadline -L ~/.brew/opt/readline/lib -I ~/.brew/opt/readline/include 
 	#home : -lreadline -L/usr/local/opt/readline/lib -I/usr/local/opt/readline/include
 $(OBJS_DIR)%.o : $(SRCS_DIR)%.c
 	@mkdir -p $(OBJS_DIR)
-	$(CC) $(CFLAGS) -c $< -o $@ -I $(INCS_DIR) -I/usr/local/opt/readline/include 
+	$(CC) $(CFLAGS) -c $< -o $@ -I $(INCS_DIR) -I ~/.brew/opt/readline/include 
 	#cluster : -I ~/.brew/opt/readline/include 
 	#home : -I/usr/local/opt/readline/include
 

--- a/minishell/srcs/error.c
+++ b/minishell/srcs/error.c
@@ -14,9 +14,8 @@
 
 int	error_handler(char *err_msg)
 {
-	(void)err_msg;
-	parse_error(0, 258);
 	printf("minishell: %s\n", err_msg);
+	parse_error(0, 258);
 	return (EXIT_FAILURE);
 }
 

--- a/minishell/srcs/exe_process.c
+++ b/minishell/srcs/exe_process.c
@@ -15,7 +15,7 @@
 void	child_process(t_cmd **cmd, char **env, t_env **env_list, t_exe exe_data)
 {
 	if (!(cmd_ok(env, (*cmd)->argv[0]) || is_built((*cmd)->argv[0])))
-		ft_error(1, (*cmd)->argv[0], " command not found\n", 127);
+		ft_error(1, (*cmd)->argv[0], "command not found\n", 127);
 	if ((*cmd)->redirect > 0)
 	{
 		if (redirect_change((*cmd)->redirect, *env_list))

--- a/minishell/srcs/main.c
+++ b/minishell/srcs/main.c
@@ -32,14 +32,12 @@ int	exe(t_cmd **cmd, char *line, t_env **env_lst, char **env)
 {	
 	t_cmd	*temp;
 
+	add_history(line);
 	if (parse_line(cmd, line, *env_lst))
 		return (EXIT_FAILURE);
 	temp = *cmd;
-	if (ft_strlen(line) > 0)
-	{
+	if (*cmd)
 		exe_process(cmd, env, env_lst);
-		add_history (line);
-	}
 	*cmd = temp;
 	return (0);
 }

--- a/minishell/srcs/parse_line.c
+++ b/minishell/srcs/parse_line.c
@@ -62,7 +62,10 @@ int	parse_line(t_cmd **cmd_lst, char *line, t_env *env)
 		if (split_line(&cmd, &line))
 			return (EXIT_FAILURE);
 		if (!*cmd)
+		{
+			free(cmd);
 			return (error_handler("syntax error near unexpected token \'|\'"));
+		}
 		new_cmd = create_cmd();
 		if (!new_cmd)
 			return (error_handler("malloc error in create_cmd()"));
@@ -72,7 +75,10 @@ int	parse_line(t_cmd **cmd_lst, char *line, t_env *env)
 		if (replace(new_cmd, env))
 			return (EXIT_FAILURE);
 		if (error_check(new_cmd))
+		{
+			free(cmd);
 			return (error_handler("syntax error near unexpected token"));
+		}
 		free(cmd);
 	}
 	return (EXIT_SUCCESS);

--- a/minishell/srcs/search_export.c
+++ b/minishell/srcs/search_export.c
@@ -1,3 +1,14 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   search_export.c                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: jiwchoi <marvin@42.fr>                     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2021/12/09 13:49:15 by jiwchoi           #+#    #+#             */
+/*   Updated: 2021/12/09 13:50:09 by jiwchoi          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
 
 #include "../includes/minishell.h"
 
@@ -56,8 +67,8 @@ int	duplicate_search(t_env *env_lst, t_env *lst)
 		}
 		else
 		{
-			if (ft_strncmp(lst->key, \
-env_lst->key, ft_strlen(env_lst->key)) == 0)
+			if (ft_strncmp(lst->key, env_lst->key,
+					ft_strlen(env_lst->key)) == 0)
 				return (init_envlst(env_lst, lst));
 		}
 		env_lst = env_lst->next;


### PR DESCRIPTION
- Makefile SRC 정렬
- error.c : error_handler()
  (void)err_msg 삭제
- exe_process.c
  42 header 삽입
- main.c : exe()
  오류 난 line도 history에 삽입되어야 해서 순서 변경
  exe_process() 진입 조건을 *cmd로 변경
- parse_line.c
  'ls | |' 처럼 파이프 사이에 아무 값도 들어오지 않았을 경우의 누수 수정
  '<<<' 처럼 unexpected token의 경우 cmd 누수 수정